### PR TITLE
feat(faces): add FacePage component with dynamic metadata and product fetching

### DIFF
--- a/app/faces/[slug]/page.tsx
+++ b/app/faces/[slug]/page.tsx
@@ -59,14 +59,18 @@ export default async function FacePage({ params, searchParams }: Props) {
   // Get current Face
   const face = faces.find((face) => face.slug === slug);
 
+  // If no matching face is found, render a 404 page
+  if (!face) {
+    notFound();
+  }
+
   // Get face banner and description
-  const faceBanner = face?.banner || {
+  const faceBanner = face.banner || {
     url: "/categories/all.webp",
     alternativeText: "Face Banner",
   };
   const faceDescription =
-    face?.description[0]?.children[0]?.text ||
-    faces[0]?.description[0]?.children[0]?.text;
+    face.description[0]?.children[0]?.text;
 
   // Flattened arrays of sizes and colors from all products
   const allSizesData = allProducts.flatMap((product) => product.sizes);

--- a/app/faces/[slug]/page.tsx
+++ b/app/faces/[slug]/page.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/lib/helper";
 import ProductSorting from "@/components/product/ProductSorting";
 import ProductsFilter from "@/components/product/ProductsFilter";
+import { notFound } from "next/navigation";
 
 type Props = {
   params: Promise<{ slug: string }>;

--- a/app/faces/[slug]/page.tsx
+++ b/app/faces/[slug]/page.tsx
@@ -1,0 +1,207 @@
+import type { Metadata } from "next";
+import { fetchFaces, fetchProductsByFace } from "@/lib/data";
+import ProductList from "../../../components/product/ProductList";
+import Link from "next/link";
+import Image from "next/image";
+import { cn } from "@/lib/utils";
+import {
+  expandProducts,
+  getAllCollections,
+  getAllColors,
+  getAllSizes,
+  getAvailableCollections,
+  getAvailableColors,
+  getAvailableSizes,
+} from "@/lib/helper";
+import ProductSorting from "@/components/product/ProductSorting";
+import ProductsFilter from "@/components/product/ProductsFilter";
+
+type Props = {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+};
+
+// Generate dynamic metadata for the category page
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  // Extract slug from params and format it for the title
+  const { slug } = await params;
+  const slugWithoutHyphens = slug.replace(/-/g, " ");
+  const capitalizedSlug = slugWithoutHyphens
+    .split(" ")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+
+  return {
+    title: `${capitalizedSlug}`,
+    description: `Explore our ${capitalizedSlug} collection. Find the perfect product that suits your style and needs.`,
+  };
+}
+
+export default async function FacePage({ params, searchParams }: Props) {
+  const { slug } = await params;
+  const { sort_by, size, color, price_min, price_max, collection } =
+    await searchParams;
+  const [{ faces }, { products }, { products: allProducts }] =
+    await Promise.all([
+      fetchFaces(),
+      fetchProductsByFace({
+        slug,
+        sort: sort_by,
+        size,
+        color,
+        price_min,
+        price_max,
+        collection,
+      }),
+      fetchProductsByFace({ slug }),
+    ]);
+
+  // Get current Face
+  const face = faces.find((face) => face.slug === slug);
+
+  // Get face banner and description
+  const faceBanner = face?.banner || {
+    url: "/categories/all.webp",
+    alternativeText: "Face Banner",
+  };
+  const faceDescription =
+    face?.description[0]?.children[0]?.text ||
+    faces[0]?.description[0]?.children[0]?.text;
+
+  // Flattened arrays of sizes and colors from all products
+  const allSizesData = allProducts.flatMap((product) => product.sizes);
+  const allColorsData = allSizesData.flatMap((size) => size.colors);
+  const allCollectionsData = allProducts.flatMap(
+    (product) => product.collections
+  );
+
+  const allSizes = getAllSizes({
+    allSizesData,
+  });
+
+  const availableSizes = getAvailableSizes({
+    color,
+    productsForAvailableSizes: products,
+  });
+
+  const allColors = getAllColors({
+    allColorsData,
+  });
+
+  const availableColors = getAvailableColors({
+    size,
+    availableProducts: products,
+  });
+
+  const allCollections = getAllCollections({
+    allCollectionsData,
+  });
+
+  const availableCollections = getAvailableCollections({
+    availableProducts: products,
+  });
+
+  // get expanded products based on selected size and color
+  const expandedProducts = expandProducts(products, size, color);
+  const resultsCount = expandedProducts.length;
+
+  return (
+    <main>
+      {/* Banner image */}
+      <section className="relative w-full h-[400px]">
+        <div className="flex items-center justify-center absolute top-0 left-0 right-0 h-[400px] after:absolute after:-inset-0 after:bg-black/20 after:content-[''] after:z-0">
+          <div>
+            <Image
+              src={faceBanner.url}
+              alt={faceBanner.alternativeText || "Face Banner"}
+              className="w-full absolute top-0 left-0 h-full object-cover object-center z-0"
+              loading="lazy"
+              width={1440}
+              height={600}
+            />
+          </div>
+          <div className="max-w-2xl space-y-4 relative z-[1] text-center">
+            <h1 className="text-4xl md:text-5xl lg:text-6xl text-white text-center font-light uppercase leading-tight tracking-tight">
+              {face?.name}
+            </h1>
+            <p className="text-sm text-white">{faceDescription}</p>
+          </div>
+        </div>
+      </section>
+      {/* Categories Bar */}
+      <div className="border-b border-border">
+        <div className="container">
+          <div className="flex items-center justify-center gap-10">
+            <span className="sticky left-0 text-sm text-gray-500 uppercase font-semibold tracking-[1px]">
+              Shop by face
+            </span>
+            <nav className="max-w-full overflow-x-auto overflow-y-hidden scrollbar-hide snap-x snap-proximity">
+              <ul className="grid grid-flow-col gap-10 min-w-max font-barlow pe-10">
+                {faces.map((face) => (
+                  <li key={face.documentId} className="py-5">
+                    <Link
+                      href={`/faces/${face.slug}`}
+                      className={cn(
+                        "relative inline-block after:absolute after:w-full after:left-0 after:h-px after:bottom-0 after:content-[''] after:bg-black after:transition-transform after:duration-200 after:ease-in-out after:scale-x-0 hover:after:scale-x-100 after:origin-right hover:after:origin-left",
+                        {
+                          "after:scale-x-100 after:origin-left":
+                            slug === face.slug,
+                        }
+                      )}
+                    >
+                      {face.name}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </nav>
+          </div>
+        </div>
+      </div>
+      <section className="container max-w-screen-xl py-10">
+        <div className="grid grid-cols-2 mb-5 gap-4">
+          <div className="flex items-center gap-10 col-span-1">
+            <ProductsFilter
+              sizes={allSizes}
+              colors={allColors}
+              collections={allCollections}
+              availableSizes={availableSizes}
+              availableColors={availableColors}
+              availableCollections={availableCollections}
+              resultsCount={resultsCount}
+            />
+            {products.length > 0 && (
+              <span className="hidden md:inline-block text-sm ">
+                {resultsCount} Results
+              </span>
+            )}
+          </div>
+          <div className="col-span-1 flex justify-end md:order-1">
+            <ProductSorting />
+          </div>
+          {products.length > 0 && (
+            <span className="md:hidden text-sm text-center col-span-2">
+              {resultsCount} Results
+            </span>
+          )}
+        </div>
+        {products.length > 0 ? (
+          <ProductList
+            products={products}
+            selectedSize={size}
+            selectedColor={color}
+          />
+        ) : (
+          <div className="flex flex-col items-center justify-center h-[250px]">
+            <h2 className="text-2xl md:text-3xl text-primary uppercase">
+              No products found
+            </h2>
+            <p className="text-sm text-gray-500">
+              Please try a different filter or check back later.
+            </p>
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -657,9 +657,7 @@ export async function fetchFaces(): Promise<{ faces: Face[] }> {
 
 // Fetch by face
 export async function fetchProductsByFace(
-  { slug, sort, size, color, price_min, price_max, collection }: filterType = {
-    sort: "createdAt:desc",
-  }
+  { slug, sort = "createdAt:desc", size, color, price_min, price_max, collection }: filterType = {}
 ): Promise<{ products: Product[] }> {
   const query = qs.stringify({
     filters: {

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -6,6 +6,7 @@ type filterType = {
 
 import {
   Category,
+  Face,
   Product,
   SingleStrapiResponse,
   StrapiResponse,
@@ -617,5 +618,135 @@ export async function fetchCategories(): Promise<{ categories: Category[] }> {
 
   return {
     categories,
+  };
+}
+
+// Fetch all faces
+export async function fetchFaces(): Promise<{ faces: Face[] }> {
+  // build deep query string to fetch product by slug with all related data
+  const query = qs.stringify({
+    populate: {
+      fields: ["name", "slug", "description"],
+      banner: {
+        fields: ["url", "alternativeText"],
+      },
+    },
+  });
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_STRAPI_API_URL}/faces?${query}&sort=createdAt:asc`,
+    {
+      headers: {
+        Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`,
+      },
+      next: { revalidate: 60 },
+    }
+  );
+
+  if (!res.ok) {
+    throw new Error("Failed to fetch faces");
+  }
+
+  const response: StrapiResponse<Face> = await res.json();
+
+  const faces = response.data;
+
+  return {
+    faces,
+  };
+}
+
+// Fetch by face
+export async function fetchProductsByFace(
+  { slug, sort, size, color, price_min, price_max, collection }: filterType = {
+    sort: "createdAt:desc",
+  }
+): Promise<{ products: Product[] }> {
+  const query = qs.stringify({
+    filters: {
+      faces: {
+        slug: {
+          $eq: slug,
+        },
+      },
+      ...((size || color) && {
+        sizes: {
+          value: Array.isArray(size) ? { $in: size } : { $eq: size },
+          colors: {
+            name: Array.isArray(color) ? { $in: color } : { $eq: color },
+          },
+        },
+      }),
+      ...(price_min !== undefined || price_max !== undefined
+        ? {
+            price: {
+              ...(price_min !== undefined && { $gte: price_min }),
+              ...(price_max !== undefined && { $lte: price_max }),
+            },
+          }
+        : {}),
+      ...(collection && {
+        collections: {
+          slug: {
+            $eq: collection,
+          },
+        },
+      }),
+    },
+    sort: [sort],
+    populate: {
+      collections: {
+        fields: ["name", "slug"],
+      },
+      categories: {
+        fields: ["name", "slug"],
+        populate: {
+          banner: {
+            fields: ["url", "alternativeText"],
+          },
+        },
+      },
+      images: {
+        fields: ["url", "alternativeText", "formats"],
+      },
+      sizes: {
+        fields: ["value"],
+        populate: {
+          colors: {
+            fields: ["name"],
+            populate: {
+              images: {
+                fields: ["url", "alternativeText", "formats"],
+              },
+              pattern: {
+                fields: ["url", "alternativeText"],
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_STRAPI_API_URL}/products?${query}`,
+    {
+      headers: {
+        Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`,
+      },
+      next: { revalidate: 60, tags: ["products", `face:${slug}`] },
+    }
+  );
+
+  if (!res.ok) {
+    throw new Error("Failed to fetch products");
+  }
+
+  const response: StrapiResponse<Product> = await res.json();
+
+  console.log("fetchProductsByFace", response);
+
+  const products = response.data;
+
+  return {
+    products,
   };
 }

--- a/lib/definitions.ts
+++ b/lib/definitions.ts
@@ -10,9 +10,9 @@ export interface Product {
   bannerBgColor: string;
   featuredBannerImg: StrapiImage;
   buyWith: Product[];
-  categories: Array<{ slug: string; name: string }>;
+  categories: Category[];
   collections: Array<{ slug: string; name: string }>;
-  faces: Array<{ slug: string; name: string; description: StrapiRichText[] }>;
+  faces: Face[];
   cart_items: Array<CartItem>;
   price: number;
   createdAt: string;
@@ -152,6 +152,17 @@ export interface Category {
   documentId: string;
   name: string;
   slug: string;
+  createdAt: string;
+  updatedAt: string;
+  publishedAt: string;
+}
+export interface Face {
+  banner: StrapiImage;
+  id: number;
+  documentId: string;
+  name: string;
+  slug: string;
+  description: StrapiRichText[];
   createdAt: string;
   updatedAt: string;
   publishedAt: string;


### PR DESCRIPTION
This pull request introduces a new feature to support "faces" as a content type in the application. It includes changes to fetch and display face-specific products, metadata, and filters on dynamically generated pages. The most important changes are grouped below by theme.

### New Feature: "Faces" Content Type
* Added a new `Face` interface to the `lib/definitions.ts` file, representing a face with properties such as `banner`, `name`, `slug`, and `description`. Updated the `Product` interface to use `Face[]` instead of a custom object for the `faces` property. [[1]](diffhunk://#diff-baf9f4de6dff2439cb927727e4a15a6f41792da749aabc30aa5620672c3086a9L13-R15) [[2]](diffhunk://#diff-baf9f4de6dff2439cb927727e4a15a6f41792da749aabc30aa5620672c3086a9R159-R169)
* Created a new function `fetchFaces` in `lib/data.ts` to retrieve all face data, including banners and descriptions, from the API.
* Added a `fetchProductsByFace` function in `lib/data.ts` to fetch products associated with a specific face, supporting filters for size, color, price range, and collections.

### Dynamic Page for Faces
* Implemented a new dynamic page component in `app/faces/[slug]/page.tsx` to display products for a specific face. This includes:
  - Dynamic metadata generation based on the face's slug.
  - A banner section with the face's image and description.
  - Filters for sizes, colors, and collections, along with sorting options.
  - A product list or a "No products found" message if no products match the filters. ([app/faces/[slug]/page.tsxR1-R207](diffhunk://#diff-429fa614f6692b436e597f685a807ee100365a5521d4df45d32d95d93c179b83R1-R207))

### API Integration
* Updated imports in `lib/data.ts` to include the newly defined `Face` type.