### PR TITLE
Perf/focal performance optimization

### DIFF
--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -2,6 +2,11 @@ import { revalidateTag } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function POST(request: NextRequest) {
+  const secret = request.headers.get("x-revalidate-secret");
+  if (secret !== process.env.REVALIDATE_SECRET) {
+    return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+  }
+
   try {
     const { tag } = await request.json();
 

--- a/app/categories/[slug]/page.tsx
+++ b/app/categories/[slug]/page.tsx
@@ -1,9 +1,12 @@
 import type { Metadata } from "next";
 import {
+  fetchAllCategorySlugs,
   fetchCategories,
   fetchProductsByCategory,
   fetchProductsByCategoryBase,
 } from "@/lib/data";
+
+export const dynamicParams = true;
 import ProductList from "@/components/product/ProductList";
 import Image from "next/image";
 import {
@@ -39,6 +42,11 @@ type Props = {
   params: Promise<{ slug: string }>;
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 };
+
+export async function generateStaticParams() {
+  const slugs = await fetchAllCategorySlugs();
+  return slugs.map((slug) => ({ slug }));
+}
 
 // Generate dynamic metadata for the category page
 export async function generateMetadata({ params }: Props): Promise<Metadata> {

--- a/app/categories/page.tsx
+++ b/app/categories/page.tsx
@@ -3,6 +3,8 @@ import {
   fetchAllProductsBase,
   fetchCategories,
 } from "@/lib/data";
+
+export const revalidate = 3600;
 import { Product } from "@/lib/definitions";
 import {
   expandProducts,

--- a/app/faces/[slug]/page.tsx
+++ b/app/faces/[slug]/page.tsx
@@ -1,9 +1,12 @@
 import type { Metadata } from "next";
 import {
+  fetchAllFaceSlugs,
   fetchFaces,
   fetchProductsByFace,
   fetchProductsByFaceBase,
 } from "@/lib/data";
+
+export const dynamicParams = true;
 import ProductList from "@/components/product/ProductList";
 import Image from "next/image";
 import {
@@ -39,6 +42,12 @@ type Props = {
   params: Promise<{ slug: string }>;
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 };
+
+// Generate static params for the face page
+export async function generateStaticParams() {
+  const slugs = await fetchAllFaceSlugs();
+  return slugs.map((slug) => ({ slug }));
+}
 
 // Generate dynamic metadata for the face page
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
@@ -80,7 +89,7 @@ export default async function FacePage({ params, searchParams }: Props) {
       price_min ||
       price_max ||
       collection ||
-      (sort_by && sort_by !== "createdAt:desc")
+      (sort_by && sort_by !== "createdAt:desc"),
   );
 
   // Fetch base data (heavily cached)
@@ -107,7 +116,7 @@ export default async function FacePage({ params, searchParams }: Props) {
 
   // Precompute filter options from ALL face products (not just base/cached results)
   const { allSizes, allColors, allCollections } = computeFilterOptions(
-    allFaceProductsForFilters
+    allFaceProductsForFilters,
   );
 
   // Calculate pagination

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,6 @@
 import Carousel from "@/components/layout/HeroCarousel";
+
+export const revalidate = 3600;
 import Categories from "@/components/layout/Categories";
 import WhyChooseUs from "@/components/shared/WhyChooseUs";
 import BestsellingSection from "@/components/layout/BestsellingSection";

--- a/app/products/[slug]/page.tsx
+++ b/app/products/[slug]/page.tsx
@@ -1,4 +1,7 @@
-import { fetchProductBySlug } from "@/lib/data";
+import { fetchAllProductSlugs, fetchProductBySlug } from "@/lib/data";
+
+export const revalidate = 3600;
+export const dynamicParams = true;
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -13,6 +16,12 @@ import FAQ from "@/components/shared/FAQ";
 import StickyProductSummary from "@/components/product/StickyProductSummry";
 import { ProductInfo } from "@/components/product/ProductInfo";
 import LazyRelatedProducts from "@/components/product/LazyRelatedProducts";
+import ScrollToTop from "@/components/product/ScrollToTop";
+
+export async function generateStaticParams() {
+  const slugs = await fetchAllProductSlugs();
+  return slugs.map((slug) => ({ slug }));
+}
 
 // fetch product data
 async function getProductData(slug: string) {
@@ -59,6 +68,7 @@ export default async function Product({
 
   return (
     <main>
+      <ScrollToTop />
       <Breadcrumb className="container max-w-screen-xl">
         <BreadcrumbList>
           <BreadcrumbItem>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -2,12 +2,15 @@ import type { MetadataRoute } from "next";
 import { fetchCategories, fetchFaces, fetchAllProducts } from "@/lib/data";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  // Fetch all categories, faces, and products
-  const [{ categories }, { faces }, { products }] = await Promise.all([
+  const [categoriesResult, facesResult, productsResult] = await Promise.allSettled([
     fetchCategories(),
     fetchFaces(),
     fetchAllProducts(),
   ]);
+
+  const categories = categoriesResult.status === "fulfilled" ? categoriesResult.value.categories : [];
+  const faces = facesResult.status === "fulfilled" ? facesResult.value.faces : [];
+  const products = productsResult.status === "fulfilled" ? productsResult.value.products : [];
 
   const baseUrl = "https://focal-mu.vercel.app";
 

--- a/components/email/EmailTemplate.tsx
+++ b/components/email/EmailTemplate.tsx
@@ -139,6 +139,7 @@ export function EmailTemplate({
                                     }}
                                   >
                                     {selectedImage && (
+                                      // eslint-disable-next-line @next/next/no-img-element
                                       <img
                                         src={selectedImage.formats.small.url}
                                         alt={item.product.name}

--- a/components/layout/HeroCarousel.tsx
+++ b/components/layout/HeroCarousel.tsx
@@ -134,6 +134,8 @@ export default function HeroCarousel() {
               activeIndex === index ? "opacity-100" : "opacity-0"
             )}
             fill
+            sizes="100vw"
+            priority={index === 0}
             loading={index === 0 ? "eager" : "lazy"}
           />
         </div>

--- a/components/layout/RevalidateButton.tsx
+++ b/components/layout/RevalidateButton.tsx
@@ -8,6 +8,7 @@ export default function RevalidateButton() {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        "x-revalidate-secret": process.env.NEXT_PUBLIC_REVALIDATE_SECRET ?? "",
       },
       body: JSON.stringify({
         tag: tag,

--- a/components/product/CarouselIndicators.tsx
+++ b/components/product/CarouselIndicators.tsx
@@ -42,7 +42,7 @@ export default function CarouselIndicators({
               src={images[index].formats?.small?.url || images[index].url}
               alt={images[index].alternativeText || "Indicator image"}
               fill
-              quality={100}
+              quality={80}
               className="object-cover object-center"
               sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
             />

--- a/components/product/FeaturedProductsSlider.tsx
+++ b/components/product/FeaturedProductsSlider.tsx
@@ -66,7 +66,8 @@ export default function FeaturedProductsSlider({
                 src={product.featuredBannerImg.url}
                 alt={product.featuredBannerImg.alternativeText}
                 fill
-                quality={100}
+                sizes="(max-width: 768px) 100vw, 50vw"
+                quality={80}
                 className="object-cover object-center"
               />
             )}

--- a/components/product/MenBanner.tsx
+++ b/components/product/MenBanner.tsx
@@ -55,7 +55,7 @@ export default function MenBanner({ product }: { product: Product }) {
               src={webBanner}
               alt="Product Banner"
               className="hidden lg:block absolute inset-0 object-cover object-center w-full h-full"
-              quality={100}
+              quality={80}
               width={2800}
               height={1400}
             />
@@ -64,7 +64,7 @@ export default function MenBanner({ product }: { product: Product }) {
               src={mobileBanner}
               alt="Product Banner"
               className="lg:hidden"
-              quality={100}
+              quality={80}
               width={1080}
               height={1080}
             />

--- a/components/product/ProductCarousel.tsx
+++ b/components/product/ProductCarousel.tsx
@@ -140,7 +140,7 @@ export default function ProductCarousel({
                   height={500}
                   width={500}
                   className="object-cover object-center aspect-auto w-full h-full"
-                  quality={100}
+                  quality={90}
                   sizes="(max-width: 768px) 50vw, (max-width: 1200px) 100vw"
                   loading={index === 0 ? "eager" : "lazy"}
                 />

--- a/components/product/ProductHotspotCard.tsx
+++ b/components/product/ProductHotspotCard.tsx
@@ -69,7 +69,7 @@ export default function ProductHotspotCard({
               alt={product.images[0].alternativeText}
               width={product.images[0].formats.thumbnail.width}
               height={product.images[0].formats.thumbnail.height}
-              quality={100}
+              quality={80}
               className="object-cover object-center h-full w-full"
             />
           </div>

--- a/components/product/ScrollToTop.tsx
+++ b/components/product/ScrollToTop.tsx
@@ -1,0 +1,7 @@
+"use client";
+import useScrollToTop from "@/hooks/useScrollToTop";
+
+export default function ScrollToTop() {
+  useScrollToTop();
+  return null;
+}

--- a/components/product/WomenBanner.tsx
+++ b/components/product/WomenBanner.tsx
@@ -57,7 +57,7 @@ export default function WomenBanner({ product }: { product: Product }) {
                 alt="Product Banner"
                 width={1800}
                 height={1800}
-                quality={100}
+                quality={80}
                 loading="lazy"
               />
             )}

--- a/components/shared/QuickViewDrawer.tsx
+++ b/components/shared/QuickViewDrawer.tsx
@@ -111,7 +111,7 @@ export default function QuickViewDrawer({
                 alt={selectedImage?.hash || "Product image"}
                 width={65}
                 height={80}
-                quality={100}
+                quality={80}
                 className="object-cover object-center"
                 priority
               />
@@ -145,7 +145,7 @@ export default function QuickViewDrawer({
               alt={selectedImage?.hash || "Product image"}
               width={120}
               height={120}
-              quality={100}
+              quality={80}
               className="object-cover object-center"
               priority
             />

--- a/components/shared/SearchDrawer.tsx
+++ b/components/shared/SearchDrawer.tsx
@@ -116,7 +116,7 @@ export default function SearchDrawer() {
                   alt={product.images[0].alternativeText}
                   width="96"
                   height="120"
-                  quality={100}
+                  quality={80}
                   className="object-cover aspect-[4/5]"
                   loading="lazy"
                 />

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -544,7 +544,7 @@ export async function fetchProductsByFaceBase(
     query,
     {
       tags: ["face-base"],
-      revalidate: 3600000, // 1 hour
+      revalidate: 3600, // 1 hour
     }
   );
 
@@ -599,7 +599,7 @@ export async function fetchProductsByFace(
     query,
     {
       tags: ["face-filtered"],
-      revalidate: 300000, // 5 minutes for filtered results
+      revalidate: 300, // 5 minutes for filtered results
     }
   );
 
@@ -700,4 +700,57 @@ export async function fetchFeaturedProducts(): Promise<{
   );
 
   return { products: response.data };
+}
+
+// Slug-only fetchers used by generateStaticParams
+
+export async function fetchAllProductSlugs(): Promise<string[]> {
+  const query = {
+    fields: ["slug"],
+    pagination: { limit: 1000, start: 0 },
+  };
+  try {
+    const response: StrapiResponse<Pick<Product, "slug">> = await fetchData(
+      "/products",
+      query,
+      { tags: ["products-base"], revalidate: 3600 }
+    );
+    return response.data.map((p) => p.slug);
+  } catch {
+    return [];
+  }
+}
+
+export async function fetchAllCategorySlugs(): Promise<string[]> {
+  const query = {
+    fields: ["slug"],
+    pagination: { limit: 100, start: 0 },
+  };
+  try {
+    const response: StrapiResponse<Pick<Category, "slug">> = await fetchData(
+      "/categories",
+      query,
+      { tags: ["categories"], revalidate: 7200 }
+    );
+    return response.data.map((c) => c.slug);
+  } catch {
+    return [];
+  }
+}
+
+export async function fetchAllFaceSlugs(): Promise<string[]> {
+  const query = {
+    fields: ["slug"],
+    pagination: { limit: 100, start: 0 },
+  };
+  try {
+    const response: StrapiResponse<Pick<Face, "slug">> = await fetchData(
+      "/faces",
+      query,
+      { tags: ["faces"], revalidate: 7200 }
+    );
+    return response.data.map((f) => f.slug);
+  } catch {
+    return [];
+  }
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,10 +1,15 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
   reactStrictMode: false,
   images: {
-    domains: ["res.cloudinary.com"],
+    formats: ["image/avif", "image/webp"],
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "res.cloudinary.com",
+      },
+    ],
   },
   experimental: {
     scrollRestoration: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "embla-carousel-autoplay": "^8.6.0",
         "embla-carousel-react": "^8.6.0",
         "lucide-react": "^0.475.0",
-        "next": "^15.2.3",
+        "next": "^15.5.15",
         "qs": "^6.14.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -945,9 +945,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.4.1.tgz",
-      "integrity": "sha512-DXQwFGAE2VH+f2TJsKepRXpODPU+scf5fDbKOME8MMyeyswe4XwgRdiiIYmBfkXU+2ssliLYznajTrOQdnLR5A==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.15.tgz",
+      "integrity": "sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -961,9 +961,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.4.1.tgz",
-      "integrity": "sha512-L+81yMsiHq82VRXS2RVq6OgDwjvA4kDksGU8hfiDHEXP+ncKIUhUsadAVB+MRIp2FErs/5hpXR0u2eluWPAhig==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.15.tgz",
+      "integrity": "sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==",
       "cpu": [
         "arm64"
       ],
@@ -977,9 +977,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.4.1.tgz",
-      "integrity": "sha512-jfz1RXu6SzL14lFl05/MNkcN35lTLMJWPbqt7Xaj35+ZWAX342aePIJrN6xBdGeKl6jPXJm0Yqo3Xvh3Gpo3Uw==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.15.tgz",
+      "integrity": "sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==",
       "cpu": [
         "x64"
       ],
@@ -993,9 +993,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.4.1.tgz",
-      "integrity": "sha512-k0tOFn3dsnkaGfs6iQz8Ms6f1CyQe4GacXF979sL8PNQxjYS1swx9VsOyUQYaPoGV8nAZ7OX8cYaeiXGq9ahPQ==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.15.tgz",
+      "integrity": "sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==",
       "cpu": [
         "arm64"
       ],
@@ -1009,9 +1009,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.4.1.tgz",
-      "integrity": "sha512-4ogGQ/3qDzbbK3IwV88ltihHFbQVq6Qr+uEapzXHXBH1KsVBZOB50sn6BWHPcFjwSoMX2Tj9eH/fZvQnSIgc3g==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.15.tgz",
+      "integrity": "sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==",
       "cpu": [
         "arm64"
       ],
@@ -1025,9 +1025,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.4.1.tgz",
-      "integrity": "sha512-Jj0Rfw3wIgp+eahMz/tOGwlcYYEFjlBPKU7NqoOkTX0LY45i5W0WcDpgiDWSLrN8KFQq/LW7fZq46gxGCiOYlQ==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.15.tgz",
+      "integrity": "sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==",
       "cpu": [
         "x64"
       ],
@@ -1041,9 +1041,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.4.1.tgz",
-      "integrity": "sha512-9WlEZfnw1vFqkWsTMzZDgNL7AUI1aiBHi0S2m8jvycPyCq/fbZjtE/nDkhJRYbSjXbtRHYLDBlmP95kpjEmJbw==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.15.tgz",
+      "integrity": "sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==",
       "cpu": [
         "x64"
       ],
@@ -1057,9 +1057,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.4.1.tgz",
-      "integrity": "sha512-WodRbZ9g6CQLRZsG3gtrA9w7Qfa9BwDzhFVdlI6sV0OCPq9JrOrJSp9/ioLsezbV8w9RCJ8v55uzJuJ5RgWLZg==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.15.tgz",
+      "integrity": "sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==",
       "cpu": [
         "arm64"
       ],
@@ -1073,9 +1073,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.4.1.tgz",
-      "integrity": "sha512-y+wTBxelk2xiNofmDOVU7O5WxTHcvOoL3srOM0kxTzKDjQ57kPU0tpnPJ/BWrRnsOwXEv0+3QSbGR7hY4n9LkQ==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.15.tgz",
+      "integrity": "sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==",
       "cpu": [
         "x64"
       ],
@@ -5649,12 +5649,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.4.1.tgz",
-      "integrity": "sha512-eNKB1q8C7o9zXF8+jgJs2CzSLIU3T6bQtX6DcTnCq1sIR1CJ0GlSyRs1BubQi3/JgCnr9Vr+rS5mOMI38FFyQw==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.15.tgz",
+      "integrity": "sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.4.1",
+        "@next/env": "15.5.15",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -5667,14 +5667,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.4.1",
-        "@next/swc-darwin-x64": "15.4.1",
-        "@next/swc-linux-arm64-gnu": "15.4.1",
-        "@next/swc-linux-arm64-musl": "15.4.1",
-        "@next/swc-linux-x64-gnu": "15.4.1",
-        "@next/swc-linux-x64-musl": "15.4.1",
-        "@next/swc-win32-arm64-msvc": "15.4.1",
-        "@next/swc-win32-x64-msvc": "15.4.1",
+        "@next/swc-darwin-arm64": "15.5.15",
+        "@next/swc-darwin-x64": "15.5.15",
+        "@next/swc-linux-arm64-gnu": "15.5.15",
+        "@next/swc-linux-arm64-musl": "15.5.15",
+        "@next/swc-linux-x64-gnu": "15.5.15",
+        "@next/swc-linux-x64-musl": "15.5.15",
+        "@next/swc-win32-arm64-msvc": "15.5.15",
+        "@next/swc-win32-x64-msvc": "15.5.15",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "embla-carousel-autoplay": "^8.6.0",
     "embla-carousel-react": "^8.6.0",
     "lucide-react": "^0.475.0",
-    "next": "^15.2.3",
+    "next": "^15.5.15",
     "qs": "^6.14.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",


### PR DESCRIPTION
## Summary

This PR delivers a full performance audit across caching, rendering strategy, scroll behavior, and image optimization for the Focal storefront.

### ISR & Caching
- Added `generateStaticParams` to product, category, and face pages so all known routes are pre-built at deploy time. New routes added after deploy are still handled via `dynamicParams = true`
- Added `export const revalidate = 3600` to pre-rendered pages (home, all-categories, product) so stale pages are rebuilt in the background every hour without blocking users
- Fixed two critical `revalidate` typos: `fetchProductsByFaceBase` was set to `3600000` (~41 days) and `fetchProductsByFace` to `300000` (~3.5 days) instead of the intended 1 hour and 5 minutes
- Added `fetchAllProductSlugs`, `fetchAllCategorySlugs`, `fetchAllFaceSlugs` with `try/catch` fallback so `generateStaticParams` returns `[]` gracefully if Strapi is cold at build time instead of failing the build

### Rendering & Build Resilience
- Wrapped `BestsellingSection` and `FeaturedSection` in `try/catch` so the home page pre-renders as an empty shell when Strapi is unavailable, rather than crashing the build
- Replaced `Promise.all` with `Promise.allSettled` in `sitemap.ts` for the same reason — a cold Strapi no longer brings down the entire sitemap generation
- Suppressed `no-img-element` ESLint error in `EmailTemplate.tsx` since raw `<img>` tags are required for email client compatibility

### Security
- Secured `/api/revalidate` with an `x-revalidate-secret` header check — unauthenticated cache busting is no longer possible

### Scroll Restoration
- Fixed a production-only scroll flash on product pages where the page briefly appeared at the previous scroll position before snapping to the top
- Implemented a `ScrollToTop` client component that calls `window.scrollTo({ top: 0, behavior: "instant" })` after hydration on every navigation to `/products/[slug]`

### Image Optimization
- Migrated `images.domains` to `images.remotePatterns` (current Next.js best practice)
- Added `images.formats: ["image/avif", "image/webp"]` so Vercel serves AVIF to supported browsers, falling back to WebP
- Added `sizes="100vw"` to `HeroCarousel` and `sizes="(max-width: 768px) 100vw, 50vw"` to `FeaturedProductsSlider` fill images to fix missing sizes Lighthouse warning
- Lowered `quality={100}` to `80`/`90` on banner and carousel components — visually indistinguishable at screen resolution, significantly smaller file sizes

### Dependency
- Updated Next.js to `15.5.15` to resolve a known security vulnerability flagged by Vercel

## Test plan
- [ ] Visit `/products/[slug]` from a category listing page and confirm no scroll position flash
- [ ] Confirm build completes successfully with Strapi running
- [ ] Confirm build completes successfully with Strapi cold/unavailable (home page renders empty sections, sitemap has only static entries)
- [ ] Verify product, category, and face pages are listed as `●` (SSG) in build output with `1h` revalidate
- [ ] Confirm `/api/revalidate` returns 401 without the correct secret header
- [ ] Check image requests in DevTools Network tab — confirm AVIF or WebP is served for Cloudinary images